### PR TITLE
Fix `where the only the` typo

### DIFF
--- a/crunch.1
+++ b/crunch.1
@@ -86,7 +86,7 @@ Specifies a starting string, eg: 03god22fs
 .HP
 \-t @,%^
 .br
-Specifies a pattern, eg: @@god@@@@ where the only the @'s, ,'s, %'s, and ^'s will change.
+Specifies a pattern, eg: @@god@@@@ where only the @'s, ,'s, %'s, and ^'s will change.
 .br
 @ will insert lower case characters
 .br


### PR DESCRIPTION
This changes `where the only the` to `where only the`.